### PR TITLE
Fixed the issue about Feb. 31 or Apr. 31 (issue #166)

### DIFF
--- a/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivity.java
+++ b/app/src/main/java/com/github/florent37/sample/singledateandtimepicker/SingleDatePickerMainActivity.java
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.res.ResourcesCompat;
 
 import com.github.florent37.singledateandtimepicker.SingleDateAndTimePicker;
+import com.github.florent37.singledateandtimepicker.dialog.SingleDateAndTimePickerDialog;
 
 public class SingleDatePickerMainActivity extends AppCompatActivity {
 
@@ -32,6 +33,19 @@ public class SingleDatePickerMainActivity extends AppCompatActivity {
             singleDateAndTimePicker.setEnabled(!singleDateAndTimePicker.isEnabled());
             singleDateAndTimePicker2.setEnabled(!singleDateAndTimePicker2.isEnabled());
         });
+
+
+
+        new SingleDateAndTimePickerDialog.Builder(this)
+                .bottomSheet()
+                .curved()
+                .displayMinutes(false)
+                .displayHours(false)
+                .displayDays(false)
+                .displayMonth(true)
+                .displayYears(true)
+                .displayDaysOfMonth(true)
+                .display();
     }
 
     private void display(String toDisplay) {


### PR DESCRIPTION
### What does this PR do?
This PR fixed the issue mentioned in #166 , we should never show Feb. 31 or Apr. 31.

### How to test manually?
- To reproduce:
    1. Build the app with the code base
    2. Run the sample app, taps on the first option: `Click me to open single dialog`
    3. Scroll to select Jan. 31
    4. Change the month picker to Feb.
    5. Check the app

- To verify:
    1. Build the app with the branch `chinalwb/SingleDateAndTimePicker`
    2. Do the same actions try to reproduce the issue
    3. Check the app

### Expected Behavior
1. [ ] The app should not show Feb. 31, that makes no sense
2. [ ] The app should show Feb. 28 or 29 (depends on the leap years)

